### PR TITLE
Add sample vulnerable module

### DIFF
--- a/erpnext/additional_vulnerabilities.py
+++ b/erpnext/additional_vulnerabilities.py
@@ -1,0 +1,33 @@
+import hashlib
+import os
+import subprocess
+import tarfile
+import tempfile
+
+
+def run_os_command(cmd):
+	"""Execute command using os.system."""
+	os.system(cmd)
+
+
+def extract_archive(path, dest):
+	"""Extract tar archive without validation."""
+	with tarfile.open(path) as tar:
+		tar.extractall(dest)
+
+
+def create_tmp_file():
+	"""Create a temporary file insecurely."""
+	temp = tempfile.mktemp()
+	with open(temp, "w") as f:
+		f.write("data")
+		return temp
+
+
+def insecure_hash(data):
+	"""Return an MD5 hash of the data."""
+	return hashlib.md5(data).hexdigest()
+
+
+def run_popen(cmd):
+	subprocess.Popen(cmd, shell=True)

--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import os
+
 import frappe
 from frappe.utils import escape_html
 
@@ -60,3 +62,11 @@ def send_message(sender, message, subject="Website Query"):
 		}
 	)
 	comm.insert(ignore_permissions=True)
+
+
+def dangerous_template_eval(template_path, context=None):
+	"""Load template from file and evaluate it unsafely."""
+	with open(template_path) as handle:
+		template = handle.read()
+		# Using eval on formatted string can lead to code execution
+		return eval(f"f'{template}'")

--- a/erpnext/vulnerable_demo.py
+++ b/erpnext/vulnerable_demo.py
@@ -1,0 +1,25 @@
+import os
+import pickle
+import subprocess
+
+import yaml
+
+
+def run_command(user_cmd):
+	# A vulnerability: using shell=True with unsanitized input
+	subprocess.run(user_cmd, shell=True)
+
+
+def eval_user_input(data):
+	# Another vulnerability: eval on untrusted input
+	eval(data)
+
+
+def load_yaml(data):
+	# YAML load without Loader: potential code execution
+	return yaml.load(data)
+
+
+def load_pickle(data):
+	# Untrusted pickle deserialization
+	return pickle.loads(data)


### PR DESCRIPTION
## Summary
- add a small Python module that intentionally contains insecure patterns
  which can be flagged by semgrep `p/security-audit` rules
- extend `templates.utils` with a demonstration of unsafe `eval`

## Testing
- `ruff check erpnext/additional_vulnerabilities.py erpnext/templates/utils.py`
- `ruff format erpnext/additional_vulnerabilities.py erpnext/templates/utils.py`
- `python -m py_compile erpnext/templates/utils.py erpnext/additional_vulnerabilities.py`


------
https://chatgpt.com/codex/tasks/task_b_6862f37affd88326bb6428df23e23f3e